### PR TITLE
[feature] 분석 기록 페이지 UI 화면 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import Signup2 from './pages/Login/Signup2.jsx'
 import Dashboard from "./pages/Dashboard/Dashboard.jsx";
 import AiSummary from "./pages/AISummary/AISummary.jsx";
 import About from "./pages/About/About.jsx";
+import History from "./pages/History/History.jsx";
 
 function App() {
   return (
@@ -21,8 +22,9 @@ function App() {
       <Route element={<AppLayout />}>
         <Route path="/" element={null} />
         <Route path="/medicine" element={<Medicine />} />
-         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/alert" element={ <Info />} />
+        <Route path="/history" element={ <History />} />
         <Route path="/demo" element={<Demo />} />
         <Route path="/ai-summary" element={<AiSummary />} />
         <Route path="/about" element={<About />} />

--- a/src/components/AiAnalysisHistory/AiAnalysisHistoryItem.jsx
+++ b/src/components/AiAnalysisHistory/AiAnalysisHistoryItem.jsx
@@ -6,7 +6,6 @@ import {useNavigate} from "react-router-dom";
 const AiAnalysisHistoryItem = ({item}) => {
   const navigate = useNavigate();
 
-
   return (
      <li className={styles.item}>
         <button type={'button'} className={styles.content} onClick={() => navigate('/ai-summary')}>{item.content}</button>

--- a/src/components/AiAnalysisHistory/AiAnalysisHistoryItem.jsx
+++ b/src/components/AiAnalysisHistory/AiAnalysisHistoryItem.jsx
@@ -1,11 +1,15 @@
 import styles from "./AiAnalysisHistoryItem.module.css";
 import HistoryItemActionMenu
   from "./HistoryItemActionMenu.jsx";
+import {useNavigate} from "react-router-dom";
 
 const AiAnalysisHistoryItem = ({item}) => {
+  const navigate = useNavigate();
+
+
   return (
      <li className={styles.item}>
-        <button type={'button'} className={styles.content}>{item.content}</button>
+        <button type={'button'} className={styles.content} onClick={() => navigate('/ai-summary')}>{item.content}</button>
         <HistoryItemActionMenu/>
      </li>
   )

--- a/src/components/AiAnalysisHistory/AiAnalysisHistorySection.jsx
+++ b/src/components/AiAnalysisHistory/AiAnalysisHistorySection.jsx
@@ -12,7 +12,7 @@ const data = [
 const AiAnalysisHistorySection = () => {
   return (
       <Card radius={'sm'}>
-        <p className={styles.title}>AI 분석 내역</p>
+        <p className={styles.title}>AI 분석 기록</p>
         <AiAnalysisHistoryList data={data}/>
       </Card>
   )

--- a/src/components/AiAnalysisHistory/HistoryItemActionMenu.jsx
+++ b/src/components/AiAnalysisHistory/HistoryItemActionMenu.jsx
@@ -12,7 +12,7 @@ const HistoryItemActionMenu = () => {
           <Popover.Portal>
             <Popover.Content side="bottom" align="center" className={styles.popover_content}>
               <div><button>이름 변경</button></div>
-              <div><button>내역 고정</button></div>
+              <div><button>내역 상단 고정</button></div>
               <div><button>삭제</button></div>
             </Popover.Content>
           </Popover.Portal>

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -24,7 +24,7 @@ const NAV_ITEMS = [
     icon: <FaPills />,
   },
   { id: "alert", label: "알림", path: "/alert", icon: <HiOutlineBellAlert /> },
-  { id: "history", label: "분석 기록", path: "/history", icon: <LuHistory /> },
+  { id: "history", label: "AI 분석 기록", path: "/history", icon: <LuHistory /> },
   {
     id: "settings",
     label: "설정",

--- a/src/components/PageHeader/PageHeader.jsx
+++ b/src/components/PageHeader/PageHeader.jsx
@@ -14,6 +14,7 @@ function PageHeader({
     <header className={pageHeaderClassName}>
       <div className={styles.textBox}>
         <h1 className={styles.title}>{title}</h1>
+        {description && <p className={styles.description}>{description}</p>}
       </div>
 
       {action && (

--- a/src/components/PageHeader/PageHeader.module.css
+++ b/src/components/PageHeader/PageHeader.module.css
@@ -10,6 +10,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  margin-bottom: 1rem;
 }
 
 .title {
@@ -18,7 +19,12 @@
   font-size: var(--font-size-title-lg);
   font-weight: var(--font-weight-bold);
   line-height: var(--line-height-title);
-  margin-bottom: 1rem;
+}
+
+.description {
+  margin: 0.375rem 0 0;
+  color: var(--sub-text-color);
+  font-size: 14px;
 }
 
 .action {

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -103,7 +103,7 @@ const Dashboard = () => {
               <Button
                 type="button"
                 size="small"
-                onClick={() => navigate("/history")}
+                onClick={() => navigate("/ai-summary")}
               >
                 상세 보기
               </Button>

--- a/src/pages/History/History.jsx
+++ b/src/pages/History/History.jsx
@@ -1,10 +1,26 @@
 import Container from "../../components/Container/Container.jsx";
 import PageHeader from "../../components/PageHeader/PageHeader.jsx";
+import AiAnalysisHistoryList
+  from "../../components/AiAnalysisHistory/AiAnalysisHistoryList.jsx";
+import Card from "../../components/Card/Card.jsx";
+
+// 임시 데이터
+const data = [
+  {id: 1, content : '분석 내역1'},
+  {id: 2, content : '분석 내역2'},
+  {id: 3, content : '분석 내역3'},
+  {id: 1, content : '분석 내역4'},
+  {id: 2, content : '분석 내역5'},
+  {id: 3, content : '분석 내역6'}
+]
 
 const History = () => {
   return (
       <Container>
-        <PageHeader title={"AI 분석 기록"} />
+        <PageHeader title={"AI 분석 기록"} description={'분석했던 내용을 언제든 다시 확인하세요'} />
+        <Card radius={'sm'}>
+          <AiAnalysisHistoryList data={data}/>
+        </Card>
       </Container>
   )
 }

--- a/src/pages/History/History.jsx
+++ b/src/pages/History/History.jsx
@@ -1,0 +1,12 @@
+import Container from "../../components/Container/Container.jsx";
+import PageHeader from "../../components/PageHeader/PageHeader.jsx";
+
+const History = () => {
+  return (
+      <Container>
+        <PageHeader title={"AI 분석 기록"} />
+      </Container>
+  )
+}
+
+export default History;


### PR DESCRIPTION
## 작업 내용
- #41 
1. /dashboard에 있는 [AI 분석 기록] 컴포넌트 -> /history 페이지에 추가
2. PageTitle 컴포넌트에 서브 타이틀 추가 작업
3. 분석 기록 -> AI 분석 기록 타이틀 통일
4. 상단 고정 기능 추가 및 '내역 고정' -> '내역 상단 고정'으로 타이틀 변경