### PR TITLE
[feature] 확인(Confirm) 모달 컴포넌트 연동

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,78 +1,103 @@
 import { Dialog } from "@radix-ui/themes";
+import { MdOutlineCheckCircle, MdOutlineInfo, MdOutlineWarningAmber } from "react-icons/md";
 import Button from "../Button/Button";
 import styles from "./Modal.module.css";
 
+const ICONS = {
+  confirm: <MdOutlineCheckCircle />,
+  info: <MdOutlineInfo />,
+  warning: <MdOutlineWarningAmber />,
+};
+
 function Modal({
   trigger,
+  open,
+  onOpenChange,
+  iconType,
   title,
   description,
   children,
-  cancelText = "취소",
-  confirmText = "확인",
-  onConfirm,
   showFooter = true,
+  showCancel = true,
+  confirmText = "확인",
+  cancelText = "취소",
+  onConfirm,
+  onCancel,
+  disableClose = false,
+  variant = "default",
   className = "",
 }) {
-  const primaryButtonStyle = {
-    backgroundColor: "var(--primary-color)",
-    border: "1px solid var(--primary-color)",
-    color: "var(--background-color)",
-  };
+  const contentClassName = [styles.content, className].filter(Boolean).join(" ");
 
-  const outlineButtonStyle = {
+  const confirmStyle =
+    variant === "destructive"
+      ? {
+          backgroundColor: "var(--danger-color, #ef4444)",
+          border: "1px solid var(--danger-color, #ef4444)",
+          color: "var(--background-color)",
+        }
+      : {
+          backgroundColor: "var(--primary-color)",
+          border: "1px solid var(--primary-color)",
+          color: "var(--background-color)",
+        };
+
+  const cancelStyle = {
     backgroundColor: "transparent",
     border: "1px solid var(--primary-color)",
     boxShadow: "none",
     color: "var(--primary-color)",
   };
 
-  const contentClassName = [styles.content, className]
-    .filter(Boolean)
-    .join(" ");
-
   return (
-    <Dialog.Root>
-      <Dialog.Trigger asChild>
-        {trigger}
-      </Dialog.Trigger>
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      {trigger && <Dialog.Trigger asChild>{trigger}</Dialog.Trigger>}
 
-      <Dialog.Content className={contentClassName}>
+      <Dialog.Content
+        className={contentClassName}
+        onInteractOutside={(e) => disableClose && e.preventDefault()}
+        onEscapeKeyDown={(e) => disableClose && e.preventDefault()}
+      >
+        {iconType && (
+          <div className={`${styles.iconWrap} ${styles[iconType]}`}>
+            {iconType === "loading" ? (
+              <div className={styles.spinner} />
+            ) : (
+              ICONS[iconType]
+            )}
+          </div>
+        )}
+
         {title && (
-          <Dialog.Title className={styles.title}>
+          <Dialog.Title className={`${styles.title} ${iconType ? styles.centered : ""}`}>
             {title}
           </Dialog.Title>
         )}
 
         {description && (
-          <Dialog.Description className={styles.description}>
+          <Dialog.Description className={`${styles.description} ${iconType ? styles.centered : ""}`}>
             {description}
           </Dialog.Description>
         )}
 
-        {children && (
-          <div className={styles.body}>
-            {children}
-          </div>
-        )}
+        {children && <div className={styles.body}>{children}</div>}
 
         {showFooter && (
           <div className={styles.footer}>
+            {showCancel && (
+              <Dialog.Close asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  style={cancelStyle}
+                  onClick={onCancel}
+                >
+                  {cancelText}
+                </Button>
+              </Dialog.Close>
+            )}
             <Dialog.Close asChild>
-              <Button
-                type="button"
-                variant="outline"
-                style={outlineButtonStyle}
-              >
-                {cancelText}
-              </Button>
-            </Dialog.Close>
-
-            <Dialog.Close asChild>
-              <Button
-                type="button"
-                style={primaryButtonStyle}
-                onClick={onConfirm}
-              >
+              <Button type="button" style={confirmStyle} onClick={onConfirm}>
                 {confirmText}
               </Button>
             </Dialog.Close>

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -4,7 +4,12 @@
   left: 50%;
   z-index: 1000;
 
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
   width: min(360px, calc(100vw - 2rem));
+  min-height: 220px;
   padding: 1.5rem;
   border-radius: var(--radius-lg);
   background-color: var(--background-color);
@@ -14,12 +19,10 @@
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
 }
 
-/* 모달 열릴 때 */
 .content[data-state="open"] {
   animation: modalShow 0.2s ease-out;
 }
 
-/* 모달 닫힐 때 */
 .content[data-state="closed"] {
   animation: modalHide 0.15s ease-in;
 }
@@ -29,7 +32,6 @@
     opacity: 0;
     transform: translate(-50%, -48%) scale(0.96);
   }
-
   to {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
@@ -41,13 +43,59 @@
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
   }
-
   to {
     opacity: 0;
     transform: translate(-50%, -48%) scale(0.96);
   }
 }
 
+/* 아이콘 */
+.iconWrap {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  margin: 0 auto 1.25rem;
+  font-size: 1.5rem;
+}
+
+.confirm {
+  background-color: color-mix(in srgb, var(--primary-color) 12%, transparent);
+  color: var(--primary-color);
+}
+
+.info {
+  background-color: rgba(59, 130, 246, 0.12);
+  color: rgb(59, 130, 246);
+}
+
+.warning {
+  background-color: rgba(239, 68, 68, 0.12);
+  color: rgb(239, 68, 68);
+}
+
+.loading {
+  background-color: color-mix(in srgb, var(--primary-color) 12%, transparent);
+}
+
+.spinner {
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 2px solid color-mix(in srgb, var(--primary-color) 25%, transparent);
+  border-top-color: var(--primary-color);
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* 타이포 */
 .title {
   margin: 0;
   font-size: var(--font-size-title-sm);
@@ -62,6 +110,10 @@
   font-weight: var(--font-weight-regular);
   line-height: var(--line-height-small);
   color: var(--sub-text-color);
+}
+
+.centered {
+  text-align: center;
 }
 
 .body {
@@ -81,6 +133,10 @@
 @media (prefers-reduced-motion: reduce) {
   .content[data-state="open"],
   .content[data-state="closed"] {
+    animation: none;
+  }
+
+  .spinner {
     animation: none;
   }
 }

--- a/src/components/UploadCard/UploadCard.jsx
+++ b/src/components/UploadCard/UploadCard.jsx
@@ -5,16 +5,16 @@ import UploadDropBox from "./UploadDropBox.jsx";
 import UploadActionBtn from "./UploadActionBtn.jsx";
 import styles from "./UploadCard.module.css";
 import { ocrScan } from "../../api/scan.js";
-import {useOcrStore} from "../../store/ocrStore.js";
+import { useOcrStore } from "../../store/ocrStore.js";
+import { useModal } from "../../providers/useModal.js";
 
 const UploadCard = () => {
   const [file, setFile] = useState(null);
   const [isDrag, setIsDrag] = useState(false);
-  const [isScanning, setIsScanning] = useState(false);
-  const [ocrError, setOcrError] = useState("");
 
   const setOcrText = useOcrStore((s) => s.setOcrText);
   const navigate = useNavigate();
+  const { loading, alert } = useModal();
 
   const handleChange = (e) => {
     const selectedFile = e.target.files[0];
@@ -31,22 +31,20 @@ const UploadCard = () => {
 
   const handleRemove = () => {
     setFile(null);
-    setOcrError("");
   };
 
   const handleCameraCapture = async (capturedFile) => {
     setFile(capturedFile);
-    setOcrError("");
-    setIsScanning(true);
+    const close = loading("AI가 처방전 정보를 분석하고 있어요!", { title: "처방전 분석 중" });
     try {
       const text = await ocrScan(capturedFile);
       setOcrText(text);
       navigate("/ai-summary");
     } catch (err) {
-      setOcrError("OCR 스캔에 실패했습니다. 다시 시도해 주세요.");
       console.error(err);
+      await alert("OCR 스캔에 실패했습니다. 다시 시도해 주세요.");
     } finally {
-      setIsScanning(false);
+      close();
     }
   };
 
@@ -54,9 +52,7 @@ const UploadCard = () => {
     <Card radius={"sm"}>
       <p className={styles.title}>처방전 업로드</p>
       <UploadDropBox isDrag={isDrag} setIsDrag={setIsDrag} onChange={handleChange} onDrop={handleDrop} file={file} />
-      <UploadActionBtn file={file} onClick={handleRemove} onCameraCapture={handleCameraCapture} isScanning={isScanning} />
-      {isScanning && <p className={styles.ocr_status}>처방전을 분석하고 있습니다...</p>}
-      {ocrError && <p className={styles.ocr_error}>{ocrError}</p>}
+      <UploadActionBtn file={file} onClick={handleRemove} onCameraCapture={handleCameraCapture} />
     </Card>
   );
 };

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,12 +5,15 @@ import { Theme } from "@radix-ui/themes";
 import "@radix-ui/themes/styles.css";
 import "./index.css";
 import App from "./App.jsx";
+import { ModalProvider } from "./providers/ModalProvider.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <Theme>
       <BrowserRouter>
-        <App />
+        <ModalProvider>
+          <App />
+        </ModalProvider>
       </BrowserRouter>
     </Theme>
   </StrictMode>,

--- a/src/providers/ModalProvider.jsx
+++ b/src/providers/ModalProvider.jsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, useState } from "react";
+import Modal from "../components/Modal/Modal";
+
+export const ModalContext = createContext(null);
+
+export function ModalProvider({ children }) {
+  const [modal, setModal] = useState(null);
+
+  const dismiss = (value) => {
+    modal?.resolve?.(value);
+    setModal(null);
+  };
+
+  const confirm = (message, options = {}) =>
+    new Promise((resolve) => {
+      setModal({ type: "confirm", message, options, resolve });
+    });
+
+  const alert = (message, options = {}) =>
+    new Promise((resolve) => {
+      setModal({ type: "alert", message, options, resolve });
+    });
+
+  const loading = (message, options = {}) => {
+    setModal({ type: "loading", message, options });
+    return () => setModal(null);
+  };
+
+  return (
+    <ModalContext.Provider value={{ confirm, alert, loading }}>
+      {children}
+      {modal && (
+        <Modal
+          open={true}
+          onOpenChange={(open) => { if (!open) dismiss(false); }}
+          iconType={
+            modal.type === "loading" ? "loading"
+            : modal.type === "alert" ? "info"
+            : modal.options?.variant === "destructive" ? "warning"
+            : "confirm"
+          }
+          title={modal.options?.title ?? (
+            modal.type === "loading" ? "잠시만 기다려주세요"
+            : modal.type === "alert" ? "안내"
+            : modal.options?.variant === "destructive" ? "주의"
+            : "확인"
+          )}
+          description={modal.message}
+          showFooter={modal.type !== "loading"}
+          showCancel={modal.type === "confirm"}
+          confirmText={modal.options?.confirmText ?? "확인"}
+          cancelText={modal.options?.cancelText ?? "취소"}
+          variant={modal.options?.variant ?? "default"}
+          disableClose={modal.type === "loading"}
+          onConfirm={() => dismiss(true)}
+          onCancel={() => dismiss(false)}
+        />
+      )}
+    </ModalContext.Provider>
+  );
+}
+

--- a/src/providers/useModal.js
+++ b/src/providers/useModal.js
@@ -1,0 +1,8 @@
+import { useContext } from "react";
+import { ModalContext } from "./ModalProvider.jsx";
+
+export function useModal() {
+  const context = useContext(ModalContext);
+  if (!context) throw new Error("useModal은 ModalProvider 안에서 사용해야 합니다.");
+  return context;
+}


### PR DESCRIPTION
## 작업 내용
- #24
## 변경 사항
### Modal 컴포넌트 확장 (`src/components/Modal/`)
기존 트리거 기반 모달에 Controlled 모드 및 스타일 개선
- `open` / `onOpenChange` props 추가 → 외부 상태로 제어 가능
- `iconType` prop 추가 → 타입별 아이콘 표시 (confirm / info / warning / loading 스피너)
- `variant="destructive"` 추가 → 삭제 등 위험 액션 시 빨간 버튼
- `disableClose` 추가 → 로딩 중 ESC / 바깥 클릭 차단
- `showCancel` 추가 → alert처럼 버튼 하나만 필요한 경우 대응
- 모달 최소 높이 및 콘텐츠 가운데 정렬 적용
### ModalProvider 추가 (`src/providers/`)
앱 어디서든 함수 호출로 모달을 띄울 수 있는 전역 컨트롤러