### PR TITLE
feat: 로그인한 사용자로 표시 및 연결

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -7,6 +7,8 @@ import { AiOutlineQuestionCircle } from "react-icons/ai";
 import { HiOutlineBellAlert } from "react-icons/hi2";
 import { MdOutlineKeyboardArrowRight } from "react-icons/md";
 import { FiMenu, FiX } from "react-icons/fi";
+import { useUserStore } from "../../store/userStore";
+import { HiOutlineLogout } from "react-icons/hi";
 
 import styles from "./Navbar.module.css";
 
@@ -37,10 +39,24 @@ export default function Navbar() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const [isOpen, setIsOpen] = useState(false);
+  const { name, email, isLoggedIn,clearUser } = useUserStore();
 
   const handleNavigate = (path) => {
     navigate(path);
     setIsOpen(false);
+  };
+
+  const handleLogout = () => {
+    if (window.confirm("로그아웃 하시겠습니까?")) {
+      clearUser(); 
+      navigate("/"); 
+    }
+  };
+
+  const displayUser = {
+    name: isLoggedIn && name ? name : "로그인 필요",
+    email: isLoggedIn && email ? email : "로그인 해주세요",
+    initial: name ? name[0] : "사",
   };
 
   return (
@@ -95,6 +111,7 @@ export default function Navbar() {
         </ul>
 
         <div className={styles.bottom}>
+          <div className={styles.bottomButtons}>
           <button
             type="button"
             className={`${styles.helpButton} ${
@@ -108,12 +125,24 @@ export default function Navbar() {
             <span className={styles.navLabel}>도움말</span>
           </button>
 
-          <button type="button" className={styles.userProfile}>
-            <div className={styles.userAvatar}>{user.initial}</div>
+          {isLoggedIn && (
+              <button
+                type="button"
+                className={styles.logoutButton}
+                onClick={handleLogout}
+              >
+                <span className={styles.navIcon}><HiOutlineLogout /></span>
+                {/* <span className={styles.navLabel}>로그아웃</span> */}
+              </button>
+            )}
+          </div>
+
+          <button type="button" className={styles.userProfile} onClick={() => handleNavigate("/profile")}>
+            <div className={styles.userAvatar}>{displayUser.initial}</div>
 
             <div className={styles.userInfo}>
-              <span className={styles.userName}>{user.name}</span>
-              <span className={styles.userEmail}>{user.email}</span>
+              <span className={styles.userName}>{displayUser.name}</span>
+              <span className={styles.userEmail}>{displayUser.email}</span>
             </div>
 
             <MdOutlineKeyboardArrowRight className={styles.chevron} />

--- a/src/components/Navbar/Navbar.module.css
+++ b/src/components/Navbar/Navbar.module.css
@@ -158,6 +158,13 @@
   padding: 1.05rem 0.75rem;
   border-top: 1px solid var(--border-color);
 }
+.bottomButtons {
+  display: flex;        
+  align-items: center;   
+  gap: 12px;            
+  padding: 0 16px;       
+  margin-bottom: 16px;   
+}
 
 .helpButton {
   display: flex;
@@ -176,6 +183,21 @@
   cursor: pointer;
 
   transition: color 0.15s ease;
+}
+.logoutButton {
+  background-color: #5e5ce6; 
+  color: white;
+  border: none;
+  border-radius: 8px;        
+  padding: 6px 12px;         
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.logoutButton:hover {
+  background-color: #4a48c5;
 }
 
 .helpButton:hover {

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -29,7 +29,7 @@ const Login = () => {
     setError('');
     try {
       const data = await loginApi(email, password);
-      setUser({ email, name: data.name ?? '', token: data.token });
+      setUser({ email: data.user.email, name: data.user.name ?? '', token: data.token });
       navigate('/dashboard');
     } catch (err) {
       setError(err.response?.data?.message ?? '로그인에 실패했습니다. 다시 시도해주세요.');


### PR DESCRIPTION
1. navbar의 사용자계정 로그인한 사용자 이름 및 이메일로 변경
2. 로그아웃 버튼 추가 
아래는 로컬에서 돌린 화면입니다.
<img width="1911" height="906" alt="image" src="https://github.com/user-attachments/assets/179fbf49-e2dc-45a4-b652-10928642226f" />
