### PR TITLE
[feature] AI 분석 내역 상단 고정 및 삭제 기능 추가

### DIFF
--- a/src/api/analysisApi.js
+++ b/src/api/analysisApi.js
@@ -27,3 +27,10 @@ export const fetchAnalysisDetail = async (id) => {
   });
   return response.data;
 };
+
+export const deleteAnalysisRecord = async (id) => {
+  const response = await axios.delete(`${API_BASE}/analysis/${id}`, {
+    headers: authHeader(),
+  });
+  return response.data;
+};

--- a/src/api/toggleAnalysisPin.js
+++ b/src/api/toggleAnalysisPin.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+const API_BASE = import.meta.env.VITE_API_BASE;
+
+const authHeader = () => {
+  const token = localStorage.getItem('token');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+// AI 분석 내역 리스트 핀 고정
+export const toggleAnalysisPin = async ({id}) => {
+  const response = await axios.patch(`${API_BASE}/analysis/${id}/pin`, {
+
+  }, {headers: authHeader()});
+  return response.data;
+};

--- a/src/components/AiAnalysisHistory/AiAnalysisHistoryItem.jsx
+++ b/src/components/AiAnalysisHistory/AiAnalysisHistoryItem.jsx
@@ -1,6 +1,7 @@
 import styles from "./AiAnalysisHistoryItem.module.css";
 import HistoryItemActionMenu from "./HistoryItemActionMenu.jsx";
 import { useNavigate } from "react-router-dom";
+import { TiPin } from "react-icons/ti";
 
 const formatDate = (dateStr) => {
   const d = new Date(dateStr);
@@ -18,19 +19,22 @@ const AiAnalysisHistoryItem = ({ item }) => {
   const title = formatTitle(item.candidates);
 
   return (
-    <li className={styles.item}>
+    <li className={`${styles.item} ${item.isPinned ? styles.pinned : ''}`}>
       <button
         type="button"
         className={styles.content}
         onClick={() => navigate(`/ai-summary/${item._id}`)}
       >
-        <span className={styles.title}>{title}</span>
+        <span className={styles.title}>
+          {item.isPinned && <TiPin className={styles.pin_icon} />}
+          <span className={styles.title_text}>{title}</span>
+        </span>
         <span className={styles.meta}>
           <span>{formatDate(item.createdAt)}</span>
           <span>약품 {item.medicineCount}개</span>
         </span>
       </button>
-      <HistoryItemActionMenu />
+      <HistoryItemActionMenu recordId={item._id} />
     </li>
   );
 };

--- a/src/components/AiAnalysisHistory/AiAnalysisHistoryItem.module.css
+++ b/src/components/AiAnalysisHistory/AiAnalysisHistoryItem.module.css
@@ -2,7 +2,12 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 2rem;
+  transition: background-color 0.2s;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.item:last-child {
+  border-bottom:0;
 }
 
 .content {
@@ -15,10 +20,23 @@
 }
 
 .title {
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  overflow: hidden;
+}
+
+.title_text {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-weight: 500;
+}
+
+.pin_icon {
+  color: #7c5cbf;
+  flex-shrink: 0;
+  font-size: 1.3rem;
 }
 
 .meta {

--- a/src/components/AiAnalysisHistory/AiAnalysisHistoryList.module.css
+++ b/src/components/AiAnalysisHistory/AiAnalysisHistoryList.module.css
@@ -3,6 +3,6 @@
   flex-direction: column;
 
   li {
-    padding:0.25rem 0;
+    padding:0.75rem 0;
   }
 }

--- a/src/components/AiAnalysisHistory/AiAnalysisHistorySection.jsx
+++ b/src/components/AiAnalysisHistory/AiAnalysisHistorySection.jsx
@@ -1,26 +1,35 @@
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Card from '../Card/Card';
 import styles from './AiAnalysisHistorySection.module.css';
 import AiAnalysisHistoryList from './AiAnalysisHistoryList.jsx';
 import HistoryEmpty from './HistoryEmpty.jsx';
 import {useAnalysisStore} from "../../store/analysisStore.js";
 
-const AiAnalysisHistorySection = () => {
-  console.log('section 렌더링');
+const AiAnalysisHistorySection = ({ limit = 3, showMore = false }) => {
   const records = useAnalysisStore((s) => s.records);
   const fetchRecords = useAnalysisStore((s) => s.fetchRecords);
+  const navigate = useNavigate();
 
-  useEffect( ()=>{
-    fetchRecords()
-  },[])
+  const displayRecords = limit ? records.slice(0, limit) : records;
 
+  useEffect(() => {
+    fetchRecords();
+  }, []);
 
   return (
     <Card radius="sm">
-      <p className={styles.title}>AI 분석 기록</p>
+      <div className={styles.header}>
+        <p className={styles.title}>AI 분석 기록</p>
+        {showMore && (
+          <button className={styles.more_button} onClick={() => navigate('/history')}>
+            더보기
+          </button>
+        )}
+      </div>
       {records.length === 0
         ? <HistoryEmpty />
-        : <AiAnalysisHistoryList data={records} />
+        : <AiAnalysisHistoryList data={displayRecords} />
       }
     </Card>
   );

--- a/src/components/AiAnalysisHistory/AiAnalysisHistorySection.jsx
+++ b/src/components/AiAnalysisHistory/AiAnalysisHistorySection.jsx
@@ -1,18 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import Card from '../Card/Card';
 import styles from './AiAnalysisHistorySection.module.css';
 import AiAnalysisHistoryList from './AiAnalysisHistoryList.jsx';
 import HistoryEmpty from './HistoryEmpty.jsx';
-import { fetchAnalysisList } from '../../api/analysisApi.js';
+import {useAnalysisStore} from "../../store/analysisStore.js";
 
 const AiAnalysisHistorySection = () => {
-  const [records, setRecords] = useState([]);
+  console.log('section 렌더링');
+  const records = useAnalysisStore((s) => s.records);
+  const fetchRecords = useAnalysisStore((s) => s.fetchRecords);
 
-  useEffect(() => {
-    fetchAnalysisList()
-      .then(setRecords)
-      .catch(console.error);
-  }, []);
+  useEffect( ()=>{
+    fetchRecords()
+  },[])
+
 
   return (
     <Card radius="sm">

--- a/src/components/AiAnalysisHistory/AiAnalysisHistorySection.module.css
+++ b/src/components/AiAnalysisHistory/AiAnalysisHistorySection.module.css
@@ -3,3 +3,23 @@
   font-size:var(--font-size-title-sm);
   font-weight:var(--font-weight-bold);
 }
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.header .title {
+  margin-bottom: 0;
+}
+
+.more_button {
+  font-size: 0.8rem;
+  color: #888;
+  cursor: pointer;
+}
+
+.more_button:hover {
+  color: #555;
+}

--- a/src/components/AiAnalysisHistory/HistoryItemActionMenu.jsx
+++ b/src/components/AiAnalysisHistory/HistoryItemActionMenu.jsx
@@ -1,8 +1,14 @@
 import { HiOutlineDotsHorizontal } from "react-icons/hi";
 import styles from "./HistoryItemActionMenu.module.css";
 import * as Popover from "@radix-ui/react-popover";
+import {useAnalysisStore} from "../../store/analysisStore.js";
 
-const HistoryItemActionMenu = () => {
+const HistoryItemActionMenu = ({recordId}) => {
+
+  const pinRecords = useAnalysisStore((s) => s.pinRecords);
+  const records = useAnalysisStore((s) => s.records);
+  const isPinned = records.find((r) => r._id === recordId)?.isPinned ?? false;
+
   return (
       <div className={styles.button}>
         <Popover.Root>
@@ -12,7 +18,7 @@ const HistoryItemActionMenu = () => {
           <Popover.Portal>
             <Popover.Content side="bottom" align="center" className={styles.popover_content}>
               <div><button>이름 변경</button></div>
-              <div><button>내역 상단 고정</button></div>
+              <div><button onClick={ () => pinRecords(recordId)}>{isPinned ? '상단 고정 해제' : '내역 상단 고정'}</button></div>
               <div><button>삭제</button></div>
             </Popover.Content>
           </Popover.Portal>

--- a/src/components/AiAnalysisHistory/HistoryItemActionMenu.jsx
+++ b/src/components/AiAnalysisHistory/HistoryItemActionMenu.jsx
@@ -6,6 +6,7 @@ import {useAnalysisStore} from "../../store/analysisStore.js";
 const HistoryItemActionMenu = ({recordId}) => {
 
   const pinRecords = useAnalysisStore((s) => s.pinRecords);
+  const deleteRecord = useAnalysisStore((s) => s.deleteRecord);
   const records = useAnalysisStore((s) => s.records);
   const isPinned = records.find((r) => r._id === recordId)?.isPinned ?? false;
 
@@ -19,7 +20,7 @@ const HistoryItemActionMenu = ({recordId}) => {
             <Popover.Content side="bottom" align="center" className={styles.popover_content}>
               <div><button>이름 변경</button></div>
               <div><button onClick={ () => pinRecords(recordId)}>{isPinned ? '상단 고정 해제' : '내역 상단 고정'}</button></div>
-              <div><button>삭제</button></div>
+              <div><button onClick={() => deleteRecord(recordId)}>삭제</button></div>
             </Popover.Content>
           </Popover.Portal>
         </Popover.Root>

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -65,7 +65,7 @@ const Dashboard = ({ rate, alarms }) => {
           {/* 처방전 업로드 */}
           <div className={styles.uploadArea}>
             <UploadCard />
-          </div>
+          </div>가
 
           {/* 오늘 상태 요약 */}
           <div className={styles.summaryArea}>
@@ -131,7 +131,7 @@ const Dashboard = ({ rate, alarms }) => {
         {/* 하단 영역 */}
         <section className={styles.bottomGrid}>
           {/* AI 분석 내역 */}
-          <AiAnalysisHistorySection />
+          <AiAnalysisHistorySection showMore={true} />
 
           {/* 다가오는 알림 */}
           <Card radius="sm">

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -65,7 +65,7 @@ const Dashboard = ({ rate, alarms }) => {
           {/* 처방전 업로드 */}
           <div className={styles.uploadArea}>
             <UploadCard />
-          </div>가
+          </div>
 
           {/* 오늘 상태 요약 */}
           <div className={styles.summaryArea}>

--- a/src/pages/History/History.jsx
+++ b/src/pages/History/History.jsx
@@ -1,29 +1,24 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import Container from "../../components/Container/Container.jsx";
 import PageHeader from "../../components/PageHeader/PageHeader.jsx";
 import AiAnalysisHistoryList from "../../components/AiAnalysisHistory/AiAnalysisHistoryList.jsx";
 import Card from "../../components/Card/Card.jsx";
 import HistoryEmpty from "../../components/AiAnalysisHistory/HistoryEmpty.jsx";
-import { fetchAnalysisList } from "../../api/analysisApi.js";
+import { useAnalysisStore } from "../../store/analysisStore.js";
 
 const History = () => {
-  const [records, setRecords] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const records = useAnalysisStore((s) => s.records);
+  const fetchRecords = useAnalysisStore((s) => s.fetchRecords);
 
   useEffect(() => {
-    fetchAnalysisList()
-      .then(setRecords)
-      .catch(console.error)
-      .finally(() => setIsLoading(false));
+    fetchRecords();
   }, []);
 
   return (
     <Container>
       <PageHeader title="AI 분석 기록" description="분석했던 내용을 언제든 다시 확인하세요" />
       <Card radius="sm">
-        {isLoading ? (
-          <p>불러오는 중...</p>
-        ) : records.length === 0 ? (
+        {records.length === 0 ? (
           <HistoryEmpty />
         ) : (
           <AiAnalysisHistoryList data={records} />

--- a/src/store/analysisStore.js
+++ b/src/store/analysisStore.js
@@ -1,0 +1,21 @@
+import {create} from 'zustand';
+import {fetchAnalysisList} from "../api/analysisApi.js";
+import {toggleAnalysisPin} from "../api/toggleAnalysisPin.js";
+
+// set: 상태 바꿀때
+// get: 다른 함수 호출
+export const useAnalysisStore = create ((set,get) => ({
+  records : [],
+  // 목록 불러오기
+  fetchRecords: async () => {
+    // API 호출 → records에 저장
+    const data = await fetchAnalysisList();
+    set({records: data})
+  },
+  // 고정 토글
+  pinRecords: async (id) => {
+    await toggleAnalysisPin({ id });
+    await get().fetchRecords();
+  },
+
+}))

--- a/src/store/analysisStore.js
+++ b/src/store/analysisStore.js
@@ -1,5 +1,5 @@
 import {create} from 'zustand';
-import {fetchAnalysisList} from "../api/analysisApi.js";
+import {fetchAnalysisList, deleteAnalysisRecord} from "../api/analysisApi.js";
 import {toggleAnalysisPin} from "../api/toggleAnalysisPin.js";
 
 // set: 상태 바꿀때
@@ -17,5 +17,9 @@ export const useAnalysisStore = create ((set,get) => ({
     await toggleAnalysisPin({ id });
     await get().fetchRecords();
   },
-
+  // 기록 삭제
+  deleteRecord: async (id) => {
+    await deleteAnalysisRecord(id);
+    await get().fetchRecords();
+  },
 }))


### PR DESCRIPTION
## 작업 내용
- #77 
- `analysisApi.js`에 `deleteAnalysisRecord(id)` 함수 추가
- `analysisStore`에 `deleteRecord` 액션 추가 (삭제 후 목록 자동 갱신)
- `HistoryItemActionMenu` 삭제 버튼에 `deleteRecord` 액션 연결
- `HistoryItemActionMenu` 고정 버튼에 `pinRecords` 액션 연결 및 고정 상태에 따른 텍스트 토글
 